### PR TITLE
Use a conductor pool rather than a single conductor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/diorama",
-  "version": "0.1.0-rc13",
+  "version": "0.1.1",
   "description": "Javascript module for orchestrating single and multi-agent scenario tests against DNAs running in the Holochain conductor",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/diorama",
-  "version": "0.1.0-rc11",
+  "version": "0.1.0-rc12",
   "description": "Javascript module for orchestrating single and multi-agent scenario tests against DNAs running in the Holochain conductor",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/diorama",
-  "version": "0.1.0-rc12",
+  "version": "0.1.0-rc13",
   "description": "Javascript module for orchestrating single and multi-agent scenario tests against DNAs running in the Holochain conductor",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -23,7 +23,7 @@
     "url": "https://github.com/holochain/diorama.git"
   },
   "dependencies": {
-    "@holochain/hachiko": "^0.1.0-rc3",
+    "@holochain/hachiko": "^0.1.0-rc4",
     "@holochain/hc-web-client": "^0.5.0",
     "colors": "^1.3.3",
     "del": "^4.1.1",

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -16,8 +16,7 @@ import logger from './logger'
 /// //////////////////////////////////////////////////////////
 
 // these should be already set when the conductor is started by `hc test`
-const ADMIN_INTERFACE_PORT = 5550
-const ADMIN_INTERFACE_URL = `ws://localhost:${ADMIN_INTERFACE_PORT}`
+const wsUrl = port => `ws://localhost:${port}`
 const ADMIN_INTERFACE_ID = 'admin-interface'
 
 const DEFAULT_ZOME_CALL_TIMEOUT = 60000
@@ -50,6 +49,7 @@ export class Conductor {
   runningInstances: Array<InstanceConfig>
   callZome: any
   testPort: number
+  adminPort: number
 
   isInitialized: boolean
 
@@ -73,7 +73,7 @@ export class Conductor {
   testInterfaceId = () => `test-interface-${this.testPort}`
 
   connectAdmin = async () => {
-    const { call, onSignal } = await this.webClientConnect({url: ADMIN_INTERFACE_URL})
+    const { call, onSignal } = await this.webClientConnect({url: wsUrl(this.adminPort)})
     this.callAdmin = method => async params => {
       logger.debug(`${colors.yellow.underline("calling")} %s`, method)
       logger.debug(JSON.stringify(params, null, 2))
@@ -104,6 +104,7 @@ export class Conductor {
   initialize = async () => {
     if (!this.isInitialized) {
       try {
+        this.adminPort = await this.getInterfacePort()
         await this.spawn()
         logger.info(colors.green.bold("test conductor spawned"))
         await this.connectAdmin()
@@ -338,7 +339,7 @@ id = "${ADMIN_INTERFACE_ID}"
 instances = []
   [interfaces.driver]
   type = "websocket"
-  port = ${ADMIN_INTERFACE_PORT}
+  port = ${this.adminPort}
 
 [logger]
 type = "debug"

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -206,6 +206,9 @@ export class Conductor {
       })
       dnaId = instance.dna.id  // XXX TODO: should be the same every time
     }
+    await this.callAdmin('admin/interface/remove')({
+      id: this.testInterfaceId(),
+    })
     await this.callAdmin('admin/dna/uninstall')({
       id: dnaId
     })

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -53,7 +53,7 @@ export class Conductor {
 
   isInitialized: boolean
 
-  constructor (connect, opts: ConductorOpts) {
+  constructor (connect, startNonce, opts: ConductorOpts) {
     this.webClientConnect = connect
     this.agentIds = new Set()
     this.dnaIds = new Set()
@@ -61,7 +61,7 @@ export class Conductor {
     this.opts = opts
     this.handle = null
     this.runningInstances = []
-    this.dnaNonce = 1
+    this.dnaNonce = startNonce
     this.onSignal = opts.onSignal
   }
 

--- a/src/executors.ts
+++ b/src/executors.ts
@@ -15,8 +15,14 @@ export const tapeExecutor = tape => (run: Runner, f, desc) => new Promise((resol
   }
   tape(desc, t => {
     run((s, ins) => f(s, t, ins))
-    .catch((e) => {
-      t.fail(e)
+    .catch((err) => {
+      try {
+        // Include stack trace from actual test function, but all on one line.
+        // This is the best we can do for now without messing with tape internals
+        t.fail(err.stack)
+      } catch (e) {
+        t.fail(err)
+      }
     })
     .then(() => {
       t.end()


### PR DESCRIPTION
This is a workaround to some memory issues in holochain core when starting and stopping many instances. By adding a conductor pool, we can shut down instances once they become too bloated (after a certain number of tests), and switch to a fresh one. Currently the pool size is 1, just running tests serially as usual, and spinning up and switching over to a fresh conductor every 5 tests.