### PR TITLE
Make signals available on test instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/diorama",
-  "version": "0.1.0-rc9",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -35,12 +35,14 @@
       }
     },
     "@holochain/hachiko": {
-      "version": "0.1.0-rc2",
-      "resolved": "https://registry.npmjs.org/@holochain/hachiko/-/hachiko-0.1.0-rc2.tgz",
-      "integrity": "sha512-wL3BkHYAMpZHRPC92KuV9Z5oyqV2utARVJnw/6Q7LAz3d85TIajfn5CMdcr2eBqFhweqPDLtdnp9HBVBTFaxEw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hachiko/-/hachiko-0.1.0.tgz",
+      "integrity": "sha512-r4dFGALyGjl5kUGDwmdOsEdUcz+DU0oDI3NsxRWO3/Ve3/ditXYosc7LRqj3TGqmEp3FBIEkJLt/nRPtvFgEhA==",
       "requires": {
         "colors": "^1.3.3",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.11",
+        "winston": "^3.2.1",
+        "winston-null": "^2.0.0"
       }
     },
     "@holochain/hc-web-client": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/diorama",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Javascript module for orchestrating single and multi-agent scenario tests against DNAs running in the Holochain conductor",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -39,7 +39,7 @@ export class Conductor {
   webClientConnect: any
   agentIds: Set<string>
   dnaIds: Set<string>
-  instanceMap: any
+  instanceMap: {[name: string]: DnaInstance}
   opts: any
   callAdmin: any
   handle: any

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -109,7 +109,7 @@ export class Conductor {
       console.log(this.instanceMap)
       const instances = Object.keys(this.instanceMap).map(key => this.instanceMap[key])
       const instance = instances.find(instance => instance.id == msg.instance_id)
-      if(instance != undefined) {
+      if(instance) {
         instance.signals.push(msg.signal)
       }
     })

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -101,6 +101,20 @@ export class Conductor {
     })
   }
 
+  connectSignals = async () => {
+    const url = this.testInterfaceUrl()
+    const { onSignal } = await this.webClientConnect({url})
+
+    onSignal((msg: {signal, instance_id: string}) => {
+      console.log(this.instanceMap)
+      const instances = Object.keys(this.instanceMap).map(key => this.instanceMap[key])
+      const instance = instances.find(instance => instance.id == msg.instance_id)
+      if(instance != undefined) {
+        instance.signals.push(msg.signal)
+      }
+    })
+  }
+
   initialize = async () => {
     if (!this.isInitialized) {
       try {
@@ -266,6 +280,7 @@ export class Conductor {
       await this.setupInstances(instanceConfigs)
       await this.setupBridges(bridgeConfigs)
       await this.startInstances(instanceConfigs)
+      await this.connectSignals()
     } catch (e) {
       this.abort(e)
     }

--- a/src/diorama.ts
+++ b/src/diorama.ts
@@ -58,7 +58,7 @@ export const DioramaClass = Conductor => class Diorama {
     this.refreshWaiter()
   }
 
-  onSignal (msg: {signal, instance_id: String}) {
+  onSignal (msg: {signal, instance_id: string}) {
     if (msg.signal.signal_type === 'Consistency') {
       // XXX, NB, this '-' magic is because of the nonced instance IDs
       // TODO: deal with this more reasonably
@@ -66,6 +66,10 @@ export const DioramaClass = Conductor => class Diorama {
       const node = msg.instance_id.substring(0, ix)
       const signal = stringifySignal(msg.signal)
       this.waiter.handleObservation({node, signal})
+    } else {
+      // sort of pseudocode
+      const {conductor} = this.currentConductor()
+      conductor.instanceMap[msg.instance_id].signals.push(msg.signal)
     }
   }
 
@@ -94,9 +98,13 @@ export const DioramaClass = Conductor => class Diorama {
       })
     }
 
-    const item = this.conductorPool[0]
+    const item = this.currentConductor()
     item.runs += 1
     return item.conductor
+  }
+
+  currentConductor () {
+    return this.conductorPool[0]
   }
 
   /**

--- a/src/diorama.ts
+++ b/src/diorama.ts
@@ -66,10 +66,6 @@ export const DioramaClass = Conductor => class Diorama {
       const node = msg.instance_id.substring(0, ix)
       const signal = stringifySignal(msg.signal)
       this.waiter.handleObservation({node, signal})
-    } else {
-      // sort of pseudocode
-      const {conductor} = this.currentConductor()
-      conductor.instanceMap[msg.instance_id].signals.push(msg.signal)
     }
   }
 

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -8,12 +8,14 @@ export class DnaInstance {
   agentAddress: string | null
   dnaAddress: string | null
   callZome: any
+  signals: Array<any>
 
   constructor (instanceId, callZome) {
     this.id = instanceId
     this.agentAddress = null
     this.dnaAddress = null
     this.callZome = callZome
+    this.signals = []
   }
 
   // internally calls `this.conductor.call`


### PR DESCRIPTION
In order to test signals as implemented in https://github.com/holochain/holochain-rust/pull/1516, we need to have Diorama listen for and store them such that they can be used for test assertions.

This adds an array `signals` to test instances so that we can get write test code like this:
```javascript
    const result = await alice.callSync("simple", "test_emit_signal", {message: "test message"})
    t.equal(alice.signals.length, 1)
    t.deepEqual(alice.signals[0], { signal_type: 'User', name: 'test-signal', arguments: '{"message":"test message"}' })
```

Diorama opens a second websocket to the same interface to avoid problems with re-instantiating the interface after instances and bridges got added (the broadcaster back channel get s lost somehow which is an issue to be solved in the conductor..)