### PR TITLE
Generate raw config rather than using admin functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/diorama",
-  "version": "0.2.0-rc.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1212,6 +1212,19 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json2toml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/json2toml/-/json2toml-1.0.6.tgz",
+      "integrity": "sha1-3DKic9Qh5l4Hgq7lETErlWSMM1Y=",
+      "requires": {
+        "lodash.foreach": "^4.1.0",
+        "lodash.isdate": "^4.0.0",
+        "lodash.isempty": "^4.1.2",
+        "lodash.isplainobject": "^4.0.2",
+        "lodash.keys": "^4.0.3",
+        "strftime": "^0.9.0"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -1270,6 +1283,31 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.isdate": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isdate/-/lodash.isdate-4.0.1.tgz",
+      "integrity": "sha1-NaVDZzuddhEN5BFLMsxXcEin82Y="
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU="
     },
     "logform": {
       "version": "2.1.2",
@@ -1813,6 +1851,11 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "strftime": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz",
+      "integrity": "sha1-vMooYfKUVtNyqvaheBHIvG859YM="
     },
     "string-width": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/diorama",
-  "version": "0.2.0",
+  "version": "0.3.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -35,9 +35,9 @@
       }
     },
     "@holochain/hachiko": {
-      "version": "0.2.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@holochain/hachiko/-/hachiko-0.2.0-rc.1.tgz",
-      "integrity": "sha512-lAvVpna/SATlj9L605DItTLGV2m+QhbGREvPX3P39eEbHak8eMzMydT01BNV5LC6HkafgoKVYpq0mrHOe5QTDg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@holochain/hachiko/-/hachiko-0.3.2.tgz",
+      "integrity": "sha512-HDlbiSCshr63Y96aU410++2i2HSRB/MLS4nvRkJlz2D+0qKaM9iKo6jVbhrsNfGc1cGHSoahbUFflzGvtA/h6Q==",
       "requires": {
         "colors": "^1.3.3",
         "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "tsc -d -w",
     "prepare": "npm run build",
     "prepublishOnly": "npm test",
-    "test": "ts-node test/index.ts",
+    "test": "ts-node test/index.ts | faucet",
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."
   },
@@ -28,6 +28,7 @@
     "colors": "^1.3.3",
     "del": "^4.1.1",
     "get-port": "^5.0.0",
+    "json2toml": "^1.0.6",
     "lodash": "^4.17.11",
     "winston": "^3.2.1",
     "winston-null": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/diorama",
-  "version": "0.2.0",
+  "version": "0.3.0-rc.1",
   "description": "Javascript module for orchestrating single and multi-agent scenario tests against DNAs running in the Holochain conductor",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -23,7 +23,7 @@
     "url": "https://github.com/holochain/diorama.git"
   },
   "dependencies": {
-    "@holochain/hachiko": "^0.2.0-rc.1",
+    "@holochain/hachiko": "^0.3.2",
     "@holochain/hc-web-client": "^0.5.0",
     "colors": "^1.3.3",
     "del": "^4.1.1",

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -10,6 +10,7 @@ const colors = require('colors/safe')
 import {Signal} from '@holochain/hachiko'
 import {promiseSerial, delay} from './util'
 import {InstanceConfig} from './types'
+import {Config} from './config'
 import {DnaInstance} from './instance'
 import logger from './logger'
 
@@ -48,46 +49,26 @@ export class Conductor {
 
   runningInstances: Array<InstanceConfig>
   callZome: any
-  testPort: number
-  adminPort: number
+  interfacePort: number
 
   isInitialized: boolean
 
-  constructor (connect, startNonce, opts: ConductorOpts) {
+  constructor (connect, opts: ConductorOpts) {
     this.webClientConnect = connect
     this.agentIds = new Set()
     this.dnaIds = new Set()
     this.instanceMap = {}
     this.opts = opts
     this.handle = null
-    this.runningInstances = []
-    this.dnaNonce = startNonce
     this.onSignal = opts.onSignal
   }
 
-  isRunning = () => {
-    return this.runningInstances.length > 0
-  }
+  testInterfaceUrl = () => `ws://localhost:${this.interfacePort}`
+  testInterfaceId = 'diorama-interface'
 
-  testInterfaceUrl = () => `ws://localhost:${this.testPort}`
-  testInterfaceId = () => `test-interface-${this.testPort}`
-
-  connectAdmin = async () => {
-    const { call, onSignal } = await this.webClientConnect({url: wsUrl(this.adminPort)})
-    this.callAdmin = method => async params => {
-      logger.debug(`${colors.yellow.underline("calling")} %s`, method)
-      logger.debug(JSON.stringify(params, null, 2))
-      const result = await call(method)(params)
-      logger.debug(`${colors.yellow.bold('->')} %j`, result)
-      return result
-    }
-
-    onSignal(this.onSignal)
-  }
-
-  connectTest = async () => {
+  connectClient = async () => {
     const url = this.testInterfaceUrl()
-    const { callZome } = await this.webClientConnect({url})
+    const { callZome, onSignal } = await this.webClientConnect({url})
     this.callZome = (...args) => params => new Promise((resolve, reject) => {
       logger.debug(colors.cyan.underline("calling"), ...args)
       logger.debug(params)
@@ -99,11 +80,6 @@ export class Conductor {
         resolve(result)
       })
     })
-  }
-
-  connectSignals = async () => {
-    const url = this.testInterfaceUrl()
-    const { onSignal } = await this.webClientConnect({url})
 
     onSignal((msg: {signal, instance_id: string}) => {
       const instances = Object.keys(this.instanceMap).map(key => this.instanceMap[key])
@@ -114,153 +90,23 @@ export class Conductor {
     })
   }
 
-  initialize = async () => {
+  initialize = async (instanceConfigs, bridgeConfigs) => {
     if (!this.isInitialized) {
-      try {
-        this.adminPort = await this.getInterfacePort()
-        await this.spawn()
-        logger.info(colors.green.bold("test conductor spawned"))
-        await this.connectAdmin()
-        logger.info(colors.green.bold("test conductor connected to admin interface"))
-      } catch (e) {
-        logger.error("Error when initializing!")
-        logger.error(e)
-        this.kill()
-      }
+      await this.spawn(instanceConfigs, bridgeConfigs)
+      this.interfacePort = await getPort()
+      await this.connectClient()
       this.isInitialized = true
     }
   }
 
-  getInterfacePort = async () => {
-    const port = await getPort()
-    // const port = await getPort({port: getPort.makeRange(5555, 5999)})
-    logger.info("using port", port)
-    return port
-  }
-
-  setupNewInterface = async () => {
-    this.testPort = await this.getInterfacePort()
-    await this.callAdmin('admin/interface/add')({
-      id: this.testInterfaceId(),
-      admin: false,
-      type: 'websocket',
-      port: this.testPort,
-    })
-  }
-
-
-  setupDna = async (nonNoncifiedInstanceId, instanceConfig) => {
-    const dnaConfig = JSON.parse(JSON.stringify(instanceConfig.dna))  // poor man's deep clone
-    dnaConfig.id += '-' + this.dnaNonce
-    dnaConfig.copy = true
-    dnaConfig.uuid = `${dnaConfig.uuid || 'uuid'}-${this.dnaNonce}`
-
-    if (!this.dnaIds.has(dnaConfig.id)) {
-      const installDnaResponse = await this.callAdmin('admin/dna/install_from_file')(dnaConfig)
-      logger.silly('installDnaResponse', installDnaResponse)
-      const dnaAddress = installDnaResponse.dna_hash
-      this.dnaIds.add(dnaConfig.id)
-      this.instanceMap[nonNoncifiedInstanceId].dnaAddress = dnaAddress
-    }
-    return dnaConfig
-  }
-
-
-  /**
-   * Calls the conductor RPC functions to initialize it according to the instances
-   */
-  setupInstances = async (instanceConfigs) => {
-    if (this.isRunning()) {
-      throw "Attempting to run a new test while another test has not yet been torn down"
-    }
-    for (const instanceConfig of instanceConfigs) {
-      const instance = JSON.parse(JSON.stringify(instanceConfig))
-      const nonNoncifiedInstanceId = instance.id
-      instance.id += '-' + this.dnaNonce
-      if (this.instanceMap[nonNoncifiedInstanceId]) {
-        const inst = new DnaInstance(instance.id, this.callZome)
-        inst.agentAddress = this.instanceMap[nonNoncifiedInstanceId].agentAddress
-        this.instanceMap[nonNoncifiedInstanceId] = inst
-      } else {
-        this.instanceMap[nonNoncifiedInstanceId] = new DnaInstance(instance.id, this.callZome)
-      }
-      if (!this.agentIds.has(instance.agent.id)) {
-        const addAgentResponse = await this.callAdmin('test/agent/add')(instance.agent)
-        logger.silly('addAgentResponse', addAgentResponse)
-        const agentAddress = addAgentResponse.agent_address
-        this.agentIds.add(instance.agent.id)
-        this.instanceMap[nonNoncifiedInstanceId].agentAddress = agentAddress
-      }
-      instance.dna = await this.setupDna(nonNoncifiedInstanceId, instance)
-      await this.callAdmin('admin/instance/add')({
-        id: instance.id,
-        agent_id: instance.agent.id,
-        dna_id: instance.dna.id,
-      })
-      await this.callAdmin('admin/interface/add_instance')({
-        interface_id: this.testInterfaceId(),  // NB: this changes between tests
-        instance_id: instance.id
-      })
-      this.runningInstances.push(instance)
-    }
-  }
-
-  teardownInstances = async () => {
-    if (!this.isRunning()) {
-      throw "Attempting teardown, but there is nothing to tear down"
-    }
-    let dnaId: string | null = null
-    for (const instance of this.runningInstances) {
-      await this.callAdmin('admin/interface/remove_instance')({
-        interface_id: this.testInterfaceId(),  // NB: this changes between tests
-        instance_id: instance.id,
-      })
-      await this.callAdmin('admin/instance/remove')({
-        id: instance.id
-      })
-      dnaId = instance.dna.id  // XXX TODO: should be the same every time
-    }
-    await this.callAdmin('admin/interface/remove')({
-      id: this.testInterfaceId(),
-    })
-    await this.callAdmin('admin/dna/uninstall')({
-      id: dnaId
-    })
-    this.runningInstances = []
+  teardown = () => {
+    logger.warn("no teardown")
   }
 
   cleanupStorage = async () => await del([
     path.join(storagePath(), 'storage'),
     path.join(storagePath(), 'dna'),
   ])
-
-
-  noncifyBridgeConfig = (bridgeConfig) => {
-    const bridge = JSON.parse(JSON.stringify(bridgeConfig))
-    bridge.caller_id += '-' + this.dnaNonce
-    bridge.callee_id += '-' + this.dnaNonce
-    return bridge
-  }
-
-  setupBridges = async (bridgeConfigs) => {
-    for (const bridgeConfig of bridgeConfigs) {
-      await this.callAdmin('admin/bridge/add')(this.noncifyBridgeConfig(bridgeConfig))
-    }
-  }
-
-  startInstances = async (instanceConfigs) => {
-    for (const instanceConfig of instanceConfigs) {
-      const instance = JSON.parse(JSON.stringify(instanceConfig))
-      instance.id += '-' + this.dnaNonce
-      await this.callAdmin('admin/instance/start')(instance)
-    }
-  }
-
-  teardownBridges = async (bridgeConfigs) => {
-    for (const bridgeConfig of bridgeConfigs) {
-      await this.callAdmin('admin/bridge/remove')(this.noncifyBridgeConfig(bridgeConfig))
-    }
-  }
 
   run = async (instanceConfigs, bridgeConfigs, fn) => {
     logger.debug('')
@@ -270,16 +116,8 @@ export class Conductor {
     logger.debug("-------  starting")
     logger.debug('')
     logger.debug('')
-    if (!this.isInitialized) {
-      throw "Cannot run uninitialized conductor"
-    }
     try {
-      await this.setupNewInterface()
-      await this.connectTest()
-      await this.setupInstances(instanceConfigs)
-      await this.setupBridges(bridgeConfigs)
-      await this.startInstances(instanceConfigs)
-      await this.connectSignals()
+      await this.initialize(instanceConfigs, bridgeConfigs)
     } catch (e) {
       this.abort(e)
     }
@@ -291,22 +129,24 @@ export class Conductor {
     }
 
     try {
-      await this.teardownBridges(bridgeConfigs)
-      await this.teardownInstances()
+      await this.teardown()
       // await this.cleanupStorage()
     } catch (e) {
       this.abort(e)
     }
-    logger.debug("Test done, tearing down instances...")
-    logger.debug("Storage cleared...")
-    this.dnaNonce += 1
+    logger.debug("Test done.")
   }
 
-  spawn () {
+  spawn (instanceConfigs, bridgeConfigs) {
     const tmpPath = storagePath()
     const configPath = path.join(tmpPath, 'conductor-config.toml')
     const persistencePath = tmpPath
-    const config = this.initialConfig(persistencePath, this.opts)
+    const config = Config.genConfig(
+      persistencePath,
+      instanceConfigs,
+      bridgeConfigs,
+      this.opts.debugLog
+    )
     fs.writeFileSync(configPath, config)
     logger.info(`Using config file at ${configPath}`)
     try {
@@ -340,38 +180,4 @@ export class Conductor {
     throw e
   }
 
-  initialConfig (persistencePath, opts) {
-    return `
-agents = []
-dnas = []
-instances = []
-persistence_dir = "${persistencePath}"
-
-[[interfaces]]
-admin = true
-id = "${ADMIN_INTERFACE_ID}"
-instances = []
-  [interfaces.driver]
-  type = "websocket"
-  port = ${this.adminPort}
-
-[logger]
-type = "debug"
-  [[logger.rules.rules]]
-  color = "red"
-  exclude = false
-  pattern = "^err/"
-  [[logger.rules.rules]]
-  color = "white"
-  exclude = false
-  pattern = "^debug/dna"
-  [[logger.rules.rules]]
-  exclude = ${opts.debugLog ? 'false' : 'true'}
-  pattern = ".*"
-
-[signals]
-trace = false
-consistency = true
-    `
-  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,15 +1,107 @@
+const child_process = require('child_process')
+const json2toml = require('json2toml')
+const getPort = require('get-port')
+
+interface DnaConfig {
+  path: string,
+  id: string,
+  hash?: string,
+}
 
 export const Config = {
   agent: id => ({ name: id, id }),
-  dna: (path, id = `${path}`) => ({ path, id }),
+  dna: (path, id = `${path}`): DnaConfig => ({ path, id }),
   bridge: (handle, caller, callee) => ({
     handle,
     caller_id: caller.name,
     callee_id: callee.name
   }),
+
   instance: (agent, dna, id = agent.id) => ({
     id,
     agent,
     dna
-  })
+  }),
+
+  getInterfacePort() {
+    return getPort()
+  },
+
+  getDnaHash (dnaPath) {
+    return child_process.exec('hc hash', dnaPath)
+  },
+
+  async genJsonConfig (persistencePath, instanceConfigs, bridgeConfigs, debugLog) {
+    const port = await this.getInterfacePort()
+    const config: any = {
+
+      agents: [],
+
+      dnas: [],
+
+      instances: [],
+
+      signals: {
+        trace: false,
+        consistency: true,
+      }
+    }
+
+    const iface = {
+      id: 'diorama-interface',
+      driver: {
+        type: 'websocket',
+        port: port,
+      },
+      instances: [] as Array<{id: string}>
+    }
+
+    const agentIds = new Set()
+    const dnaIds = new Set()
+
+    for (const instance of instanceConfigs) {
+      if (!agentIds.has(instance.agent.id)) {
+        config.agents.push(instance.agent)
+      }
+      if (!dnaIds.has(instance.dna.id)) {
+        if (!instance.dna.hash) {
+          instance.dna.hash = await this.getDnaHash(instance.dna.path)
+        }
+        config.dnas.push(instance.dna)
+      }
+      config.instances.push({
+        id: instance.id,
+        agent_id: instance.agent.id,
+        dna_id: instance.dna.id,
+      })
+      iface.instances.push({id: instance.id})
+    }
+
+    config.interfaces = [iface]
+
+    return config
+  },
+
+  async genConfig (persistencePath, instanceConfigs, bridgeConfigs, debugLog) {
+
+    const config = this.genJsonConfig(persistencePath, instanceConfigs, bridgeConfigs, debugLog)
+
+    const toml = json2toml(config) + `
+[logger]
+type = "debug"
+  [[logger.rules.rules]]
+  color = "red"
+  exclude = false
+  pattern = "^err/"
+  [[logger.rules.rules]]
+  color = "white"
+  exclude = false
+  pattern = "^debug/dna"
+  [[logger.rules.rules]]
+  exclude = ${debugLog ? 'false' : 'true'}
+  pattern = ".*"
+`
+    return toml
+
+  }
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,5 +1,6 @@
 
 
-require('./test-executor')
-require('./test-middleware')
-require('./test-diorama')
+require('./test-config')
+// require('./test-executor')
+// require('./test-middleware')
+// require('./test-diorama')

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,5 @@
 
-
 require('./test-config')
-// require('./test-executor')
-// require('./test-middleware')
-// require('./test-diorama')
+require('./test-executor')
+require('./test-middleware')
+require('./test-diorama')

--- a/test/test-config.ts
+++ b/test/test-config.ts
@@ -1,0 +1,62 @@
+import {Config} from '../src/config'
+
+// mock out the effectful bits
+Config.getDnaHash = (path) => 'fakednahash'
+Config.getInterfacePort = () => 9000
+
+import * as test from 'tape'
+
+const [aliceConfig, bobConfig] = ['alice', 'bob'].map(name => ({
+  id: name,
+  agent: Config.agent(name),
+  dna: Config.dna(name),
+}))
+
+const expectedJsonConfig = {
+  agents: [
+    {id: 'alice', name: 'alice'},
+    {id: 'bob', name: 'bob'},
+  ],
+  dnas: [
+    {id: 'alice', path: 'alice', hash: 'fakednahash'},
+    {id: 'bob', path: 'bob', hash: 'fakednahash'},
+  ],
+  instances: [
+    {id: 'alice', agent_id: 'alice', dna_id: 'alice'},
+    {id: 'bob', agent_id: 'bob', dna_id: 'bob'},
+  ],
+  interfaces: [{
+    id: 'diorama-interface',
+    driver: {
+      type: 'websocket',
+      port: 9000,
+    },
+    instances: [
+      {id: 'alice'},
+      {id: 'bob'},
+    ]
+  }],
+  signals: {
+    trace: false,
+    consistency: true,
+  }
+}
+
+test("test config json generation", async t => {
+  const instances = [aliceConfig, bobConfig]
+  const bridges = [
+    Config.bridge('bridge', 'alice', 'bob')
+  ]
+  const config = await Config.genJsonConfig('path/to/persistence', instances, bridges, false)
+
+  t.deepEqual(config, expectedJsonConfig)
+  t.end()
+})
+
+test("test config toml generation", async t => {
+  const instances = [aliceConfig, bobConfig]
+  const bridges = [Config.bridge('bridge', 'alice', 'bob')]
+  const toml = await Config.genConfig('path/to/persistence', instances, bridges, false)
+  t.ok(toml.includes('[logger]'))
+  t.end()
+})

--- a/test/test-diorama.ts
+++ b/test/test-diorama.ts
@@ -4,7 +4,7 @@ import {DioramaClass} from '../src/diorama'
 import * as test from 'tape'
 
 
-test('a', async t => {
+test('can run heavily mocked Diorama', async t => {
 
   class TestConductor {
     initialize() {}


### PR DESCRIPTION
In preparation for adding DPKI configurability, which has no corresponding admin interface method.

By removing the need for using the admin interface, the code gets much, much simpler. We can specify config declaratively by generating the config toml directly, and not modifying config state throughout the course of the test. The old way of using admin functions was put in place when we were considering using the same conductor for multiple tests, and holding onto common DNAs and agents, but since we are using a fresh conductor for every test anyway, this makes more sense and is much more maintainable.